### PR TITLE
Methods for creating leading and trailing constraints

### DIFF
--- a/Example/S2MToolbox.xcodeproj/project.pbxproj
+++ b/Example/S2MToolbox.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		01F0619E1A3A0014000EE282 /* UIView_S2MAdditionsSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F0619D1A3A0014000EE282 /* UIView_S2MAdditionsSpec.m */; };
 		129A5059D8FA56DE6C24CD68 /* libPods-S2MToolbox.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 214EEC8690751CED95D51973 /* libPods-S2MToolbox.a */; };
 		630E44400A0BD9072C48D213 /* libPods-S2MToolboxTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D7A35DAE158208DEB0010B28 /* libPods-S2MToolboxTests.a */; };
+		89E8C1931B0A3C4B00829FF0 /* UIView+S2MAutolayoutTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89E8C1921B0A3C4B00829FF0 /* UIView+S2MAutolayoutTests.m */; };
 		CA4363E21A3AF8EF000CD51C /* S2MShopFinderSearchDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = CA4363DD1A3AF8EF000CD51C /* S2MShopFinderSearchDelegate.m */; };
 		CA4363E61A3AF921000CD51C /* StartViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CA4363E51A3AF921000CD51C /* StartViewController.m */; };
 		CA4363E91A3AF960000CD51C /* S2MViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CA4363E81A3AF960000CD51C /* S2MViewController.m */; };
@@ -76,6 +77,7 @@
 		379B16138C54DA63B3D555BA /* libPods-RefreshControl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RefreshControl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3ACA180F9C8D9F3FCA7AEFDA /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		420AF7947B11A286698A0A7C /* Pods-S2MToolboxTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-S2MToolboxTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-S2MToolboxTests/Pods-S2MToolboxTests.debug.xcconfig"; sourceTree = "<group>"; };
+		89E8C1921B0A3C4B00829FF0 /* UIView+S2MAutolayoutTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIView+S2MAutolayoutTests.m"; sourceTree = "<group>"; };
 		9D9AF81FC94A90E8F53FD5E9 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2FBA20F086BD9320FFB1F78 /* Pods-S2MToolboxTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-S2MToolboxTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-S2MToolboxTests/Pods-S2MToolboxTests.release.xcconfig"; sourceTree = "<group>"; };
 		B3A25DCBE12AC3283FC05B74 /* Pods-S2MToolbox.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-S2MToolbox.release.xcconfig"; path = "Pods/Target Support Files/Pods-S2MToolbox/Pods-S2MToolbox.release.xcconfig"; sourceTree = "<group>"; };
@@ -230,6 +232,7 @@
 		01C12EB519FE5C65004B7999 /* S2MToolboxTests */ = {
 			isa = PBXGroup;
 			children = (
+				89E8C1911B0A3C1100829FF0 /* UIKit */,
 				0169E2951A39DE930036D375 /* Core */,
 				01C12EB619FE5C65004B7999 /* Supporting Files */,
 			);
@@ -258,6 +261,14 @@
 				020964E8F6A4B4C0780776B8 /* Pods.release.xcconfig */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		89E8C1911B0A3C1100829FF0 /* UIKit */ = {
+			isa = PBXGroup;
+			children = (
+				89E8C1921B0A3C4B00829FF0 /* UIView+S2MAutolayoutTests.m */,
+			);
+			name = UIKit;
 			sourceTree = "<group>";
 		};
 		CA4363D71A3AF8EF000CD51C /* Example */ = {
@@ -466,6 +477,7 @@
 			files = (
 				0169E2971A39DEED0036D375 /* NSString_S2MMD5Spec.m in Sources */,
 				0169E2991A39E2260036D375 /* NSString_S2MRegExValidationSpec.m in Sources */,
+				89E8C1931B0A3C4B00829FF0 /* UIView+S2MAutolayoutTests.m in Sources */,
 				01F0619E1A3A0014000EE282 /* UIView_S2MAdditionsSpec.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/S2MToolboxTests/UIView+S2MAutolayoutTests.m
+++ b/Example/S2MToolboxTests/UIView+S2MAutolayoutTests.m
@@ -1,0 +1,108 @@
+
+#import <XCTest/XCTest.h>
+#import "UIView+S2MAutolayout.h"
+
+@interface UIView_S2MAutolayoutTests : XCTestCase
+
+@property (nonatomic, weak) UIView *sut;
+@property (nonatomic, strong) UIView *superView;
+@end
+
+@implementation UIView_S2MAutolayoutTests
+
+- (void)setUp {
+    [super setUp];
+    self.superView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 320, 640)];
+	UILabel *label = [[UILabel alloc] init];
+	[self.superView addSubview:label];
+	self.sut = label;
+}
+
+- (void)tearDown {
+	self.sut = nil;
+	self.superView = nil;
+    [super tearDown];
+}
+
+
+
+#pragma mark - s2m_addLeadingConstraint Tests
+
+- (void)testAddLeadingConstraint_addsOneConstraintToSuperView {
+	[self.sut s2m_addLeadingConstraint:10];
+	
+	XCTAssertEqual([self.superView.constraints count], 1);
+}
+
+- (void)testAddLeadingConstraint_addedConstraintIsReturnedConstraint {
+	NSLayoutConstraint *returnedConstraint = [self.sut s2m_addLeadingConstraint:10];
+	NSLayoutConstraint *addedConstraint = [self.superView.constraints firstObject];
+	
+	XCTAssertEqualObjects(returnedConstraint, addedConstraint);
+}
+
+- (void)testAddLeadingConstraint_addedConstraintDataIsCorrect {
+	NSLayoutConstraint *constraint = [self.sut s2m_addLeadingConstraint:10];
+	
+	XCTAssertEqualObjects(constraint.firstItem, self.sut);
+	XCTAssertEqual(constraint.firstAttribute, NSLayoutAttributeLeading);
+	
+	XCTAssertEqual(constraint.relation, NSLayoutRelationEqual);
+	
+	XCTAssertEqualObjects(constraint.secondItem, self.superView);
+	XCTAssertEqual(constraint.secondAttribute, NSLayoutAttributeLeading);
+	
+	XCTAssertEqual(constraint.multiplier, 1.0);
+	XCTAssertEqual(constraint.constant, 10);
+	
+	XCTAssertEqual(constraint.priority, 1000);
+}
+
+- (void)testAddLeadingConstraint_addedConstraintIsActive {
+	NSLayoutConstraint *constraint = [self.sut s2m_addLeadingConstraint:10];
+	
+	XCTAssertEqual(constraint.active, YES);
+}
+
+
+
+#pragma mark - s2m_addTrailingConstraint Tests
+
+- (void)testAddTrailingConstraint_addsOneConstraintToSuperView {
+	[self.sut s2m_addTrailingConstraint:10];
+	
+	XCTAssertEqual([self.superView.constraints count], 1);
+}
+
+- (void)testAddTrailingConstraint_addedConstraintIsReturnedConstraint {
+	NSLayoutConstraint *returnedConstraint = [self.sut s2m_addTrailingConstraint:10];
+	NSLayoutConstraint *addedConstraint = [self.superView.constraints firstObject];
+	
+	XCTAssertEqualObjects(returnedConstraint, addedConstraint);
+}
+
+- (void)testAddTrailingConstraint_addedConstraintDataIsCorrect {
+	NSLayoutConstraint *constraint = [self.sut s2m_addTrailingConstraint:10];
+	
+	XCTAssertEqualObjects(constraint.firstItem, self.sut);
+	XCTAssertEqual(constraint.firstAttribute, NSLayoutAttributeTrailing);
+	
+	XCTAssertEqual(constraint.relation, NSLayoutRelationEqual);
+	
+	XCTAssertEqualObjects(constraint.secondItem, self.superView);
+	XCTAssertEqual(constraint.secondAttribute, NSLayoutAttributeTrailing);
+	
+	XCTAssertEqual(constraint.multiplier, 1.0);
+	XCTAssertEqual(constraint.constant, 10);
+	
+	XCTAssertEqual(constraint.priority, 1000);
+}
+
+- (void)testAddTrailingConstraint_addedConstraintIsActive {
+	NSLayoutConstraint *constraint = [self.sut s2m_addTrailingConstraint:10];
+	
+	XCTAssertEqual(constraint.active, YES);
+}
+
+
+@end

--- a/Example/S2MToolboxTests/UIView+S2MAutolayoutTests.m
+++ b/Example/S2MToolboxTests/UIView+S2MAutolayoutTests.m
@@ -61,7 +61,13 @@
 - (void)testAddLeadingConstraint_addedConstraintIsActive {
 	NSLayoutConstraint *constraint = [self.sut s2m_addLeadingConstraint:10];
 	
-	XCTAssertEqual(constraint.active, YES);
+	if ([constraint respondsToSelector:@selector(isActive)]) {
+		XCTAssertEqual(constraint.active, YES);
+	} else {
+		// 'active' is available since iOS 8. On older systems all installed constraints are active.
+		XCTAssertTrue(YES);
+	}
+	
 }
 
 
@@ -101,7 +107,12 @@
 - (void)testAddTrailingConstraint_addedConstraintIsActive {
 	NSLayoutConstraint *constraint = [self.sut s2m_addTrailingConstraint:10];
 	
-	XCTAssertEqual(constraint.active, YES);
+	if ([constraint respondsToSelector:@selector(isActive)]) {
+		XCTAssertEqual(constraint.active, YES);
+	} else {
+		// 'active' is available since iOS 8. On older systems all installed constraints are active.
+		XCTAssertTrue(YES);
+	}
 }
 
 

--- a/UIKit/UIView+S2MAutolayout.h
+++ b/UIKit/UIView+S2MAutolayout.h
@@ -32,6 +32,9 @@
 -(NSLayoutConstraint*)s2m_addRightConstraint:(CGFloat)constant;
 -(NSLayoutConstraint*)s2m_addLeftConstraint:(CGFloat)constant;
 
+-(NSLayoutConstraint*)s2m_addLeadingConstraint:(CGFloat)constant;
+-(NSLayoutConstraint*)s2m_addTrailingConstraint:(CGFloat)constant;
+
 -(NSArray*)s2m_addLeftRightConstraint:(CGFloat)constant;
 -(NSArray*)s2m_addTopBottomConstraint:(CGFloat)constant;
 

--- a/UIKit/UIView+S2MAutolayout.m
+++ b/UIKit/UIView+S2MAutolayout.m
@@ -235,40 +235,40 @@
 
 - (NSLayoutConstraint *)s2m_addLeadingConstraint:(CGFloat)constant
 {
-	if (!self.superview) {
-		return nil;
-	}
-	self.translatesAutoresizingMaskIntoConstraints = NO;
-	
-	NSLayoutConstraint* constraint = [NSLayoutConstraint constraintWithItem:self
-																  attribute:NSLayoutAttributeLeading
-																  relatedBy:NSLayoutRelationEqual
-																	 toItem:self.superview
-																  attribute:NSLayoutAttributeLeading
-																 multiplier:1.0
-																   constant:constant];
-	
-	[self.superview addConstraint:constraint];
-	return constraint;
+    if (!self.superview) {
+        return nil;
+    }
+    self.translatesAutoresizingMaskIntoConstraints = NO;
+    
+    NSLayoutConstraint* constraint = [NSLayoutConstraint constraintWithItem:self
+                                                                  attribute:NSLayoutAttributeLeading
+                                                                  relatedBy:NSLayoutRelationEqual
+                                                                     toItem:self.superview
+                                                                  attribute:NSLayoutAttributeLeading
+                                                                 multiplier:1.0
+                                                                   constant:constant];
+    
+    [self.superview addConstraint:constraint];
+    return constraint;
 }
 
 - (NSLayoutConstraint *)s2m_addTrailingConstraint:(CGFloat)constant
 {
-	if (!self.superview) {
-		return nil;
-	}
-	self.translatesAutoresizingMaskIntoConstraints = NO;
-	
-	NSLayoutConstraint* constraint = [NSLayoutConstraint constraintWithItem:self
-																  attribute:NSLayoutAttributeTrailing
-																  relatedBy:NSLayoutRelationEqual
-																	 toItem:self.superview
-																  attribute:NSLayoutAttributeTrailing
-																 multiplier:1.0
-																   constant:constant];
-	
-	[self.superview addConstraint:constraint];
-	return constraint;
+    if (!self.superview) {
+        return nil;
+    }
+    self.translatesAutoresizingMaskIntoConstraints = NO;
+    
+    NSLayoutConstraint* constraint = [NSLayoutConstraint constraintWithItem:self
+                                                                  attribute:NSLayoutAttributeTrailing
+                                                                  relatedBy:NSLayoutRelationEqual
+                                                                     toItem:self.superview
+                                                                  attribute:NSLayoutAttributeTrailing
+                                                                 multiplier:1.0
+                                                                   constant:constant];
+    
+    [self.superview addConstraint:constraint];
+    return constraint;
 }
 
 

--- a/UIKit/UIView+S2MAutolayout.m
+++ b/UIKit/UIView+S2MAutolayout.m
@@ -233,6 +233,44 @@
     return constraints;
 }
 
+- (NSLayoutConstraint *)s2m_addLeadingConstraint:(CGFloat)constant
+{
+	if (!self.superview) {
+		return nil;
+	}
+	self.translatesAutoresizingMaskIntoConstraints = NO;
+	
+	NSLayoutConstraint* constraint = [NSLayoutConstraint constraintWithItem:self
+																  attribute:NSLayoutAttributeLeading
+																  relatedBy:NSLayoutRelationEqual
+																	 toItem:self.superview
+																  attribute:NSLayoutAttributeLeading
+																 multiplier:1.0
+																   constant:constant];
+	
+	[self.superview addConstraint:constraint];
+	return constraint;
+}
+
+- (NSLayoutConstraint *)s2m_addTrailingConstraint:(CGFloat)constant
+{
+	if (!self.superview) {
+		return nil;
+	}
+	self.translatesAutoresizingMaskIntoConstraints = NO;
+	
+	NSLayoutConstraint* constraint = [NSLayoutConstraint constraintWithItem:self
+																  attribute:NSLayoutAttributeTrailing
+																  relatedBy:NSLayoutRelationEqual
+																	 toItem:self.superview
+																  attribute:NSLayoutAttributeTrailing
+																 multiplier:1.0
+																   constant:constant];
+	
+	[self.superview addConstraint:constraint];
+	return constraint;
+}
+
 
 
 #pragma mark - Specific Height


### PR DESCRIPTION
I added two methods similar to the existing methods for creating left & right constraints. The difference is that leading & trailing constraints are created instead. This would be beneficial for apps supporting right-to-left languages.